### PR TITLE
reset resume token if kid list is empty

### DIFF
--- a/DGCAVerifier/Services/GatewayConnection.swift
+++ b/DGCAVerifier/Services/GatewayConnection.swift
@@ -92,6 +92,9 @@ struct GatewayConnection {
                 return
             }
             let kids = json.compactMap { $0.string }
+            if kids.isEmpty {
+                LocalData.sharedInstance.resumeToken = nil
+            }
             completion?(kids)
         }
     }


### PR DESCRIPTION
Resume token is reset to nil if no kids are downloaded, to restart downloading at the next update