### PR TITLE
Feature/medical rules

### DIFF
--- a/DGCAVerifier/Models/LocalData.swift
+++ b/DGCAVerifier/Models/LocalData.swift
@@ -35,6 +35,7 @@ struct LocalData: Codable {
   var encodedPublicKeys = [String: [String]]()
   var resumeToken: String?
   var lastFetchRaw: Date?
+  var settings = [Setting]()
   var lastFetch: Date {
     get {
       lastFetchRaw ?? .init(timeIntervalSince1970: 0)
@@ -53,6 +54,14 @@ struct LocalData: Codable {
       return
     }
     encodedPublicKeys[kidStr] = list + [encodedPublicKey]
+  }
+    
+  mutating func addOrUpdateSettings(_ setting: Setting) {
+    if let i = settings.firstIndex(where: { $0.name == setting.name && $0.type == setting.type }) {
+        settings[i].value = setting.value
+        return
+    }
+    settings = settings + [setting]
   }
 
   static func set(resumeToken: String) {

--- a/DGCAVerifier/Models/RecoveryValidityCheck.swift
+++ b/DGCAVerifier/Models/RecoveryValidityCheck.swift
@@ -1,0 +1,26 @@
+//
+//  RecoveryValidityCheck.swift
+//  Verifier
+//
+//  Created by Davide Aliti on 21/05/21.
+//
+
+import Foundation
+import SwiftDGC
+
+struct RecoveryValidityCheck {
+    
+    func checkRecoveryDate(_ hcert: HCert) -> Bool {
+        let recoveryStartDays = LocalData.sharedInstance.settings.filter{ $0.name == "recovery_cert_start_day"}.first?.value ?? "0"
+        let recoveryEndDays = LocalData.sharedInstance.settings.filter{ $0.name == "recovery_cert_end_day"}.first?.value ?? "0"
+        let recoveryValidFromTimeAsString = hcert.statement.info.filter{ $0.header == l10n("recovery.valid-from")}.first?.content
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = .current
+        dateFormatter.timeStyle = .none
+        dateFormatter.dateStyle = .medium
+        let recoveryValidFromTime = dateFormatter.date(from: recoveryValidFromTimeAsString!)
+        let recoveryValidityStart = Calendar.current.date(byAdding: .day, value: Int(recoveryStartDays) ?? 0, to: recoveryValidFromTime!)!
+        let recoveryValidityEnd = Calendar.current.date(byAdding: .day, value: Int(recoveryEndDays) ?? 0, to: recoveryValidFromTime!)!
+        return (Date() > recoveryValidityStart && Date() < recoveryValidityEnd)
+    }
+}

--- a/DGCAVerifier/Models/Setting.swift
+++ b/DGCAVerifier/Models/Setting.swift
@@ -1,0 +1,20 @@
+//
+//  MedicalRule.swift
+//  Verifier
+//
+//  Created by Davide Aliti on 20/05/21.
+//
+
+import Foundation
+
+struct Setting: Codable {
+    var name: String
+    var type: String
+    var value: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case value
+    }
+}

--- a/DGCAVerifier/Models/TestValidityCheck.swift
+++ b/DGCAVerifier/Models/TestValidityCheck.swift
@@ -1,0 +1,30 @@
+//
+//  TestValidityCheck.swift
+//  Verifier
+//
+//  Created by Davide Aliti on 21/05/21.
+//
+
+import Foundation
+import SwiftDGC
+
+struct TestValidityCheck {
+    func checkTestResult(_ hcert: HCert) -> Bool {
+        return hcert.statement.info.filter{ $0.header == l10n("test.test-result")}.first?.content == l10n("test.result.negative")
+    }
+    
+    func checkTestDate(_ hcert: HCert) -> Bool {
+        let testStartHours = LocalData.sharedInstance.settings.filter{ $0.name == "rapid_test_start_hours"}.first?.value ?? "0"
+        let testEndHours = LocalData.sharedInstance.settings.filter{ $0.name == "rapid_test_end_hours"}.first?.value ?? "0"
+        let testSampleDateTimeAsString = hcert.statement.info.filter{ $0.header == l10n("test.sample-date-time")}.first?.content
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = .current
+        dateFormatter.timeStyle = .medium
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeZone = .init(secondsFromGMT: 0)
+        let testSampleDateTime = dateFormatter.date(from: testSampleDateTimeAsString!.replacingOccurrences(of: " (UTC)", with: ""))
+        let testValidityStart = Calendar.current.date(byAdding: .hour, value: Int(testStartHours) ?? 0, to: testSampleDateTime!)!
+        let testValidityEnd = Calendar.current.date(byAdding: .hour, value: Int(testEndHours) ?? 0, to: testSampleDateTime!)!
+        return (Date() > testValidityStart && Date() < testValidityEnd)
+    }
+}

--- a/DGCAVerifier/Models/VaccineValidityCheck.swift
+++ b/DGCAVerifier/Models/VaccineValidityCheck.swift
@@ -1,0 +1,48 @@
+//
+//  VaccineValidityCheck.swift
+//  Verifier
+//
+//  Created by Davide Aliti on 21/05/21.
+//
+
+import Foundation
+import SwiftDGC
+
+struct VaccineValidityCheck {
+    
+    func checkVaccineDate(_ hcert: HCert) -> Bool {
+        let vaccineDoseString = hcert.statement.typeAddon
+        let vaccineDosesArray = getDosesFromDoseString(from: vaccineDoseString)
+        
+        let isLastDose = vaccineDosesArray.first == vaccineDosesArray.last
+        
+        let vaccineMedicalProduct = hcert.statement.info.filter{ $0.header == l10n("vaccine.product")}.first?.content ?? ""
+        let availableMedicalProductsInSettings = LocalData.sharedInstance.settings.filter { $0.name == "vaccine_end_day_complete"}.map { $0.type }
+        let vaccineMedicalProductCode = availableMedicalProductsInSettings.filter { l10n("vac.product.\($0)") == vaccineMedicalProduct }
+        
+        // Vaccine code not included in settings -> not a valid vaccine for Italy
+        if vaccineMedicalProductCode.isEmpty {
+            return false
+        }
+        // Vaccine code included in settings -> check dates, checking if it is lastDose or not too
+        let settingsNameStartDays = isLastDose ? "vaccine_start_day_complete" : "vaccine_start_day_not_complete"
+        let settingsNameEndDays = isLastDose ? "vaccine_end_day_complete" : "vaccine_end_day_not_complete"
+        let vaccineStartDays = LocalData.sharedInstance.settings.filter{ $0.name == settingsNameStartDays && $0.type == vaccineMedicalProductCode[0] }.first?.value ?? "0"
+        let vaccineEndDays = LocalData.sharedInstance.settings.filter{ $0.name == settingsNameEndDays  && $0.type == vaccineMedicalProductCode[0] }.first?.value ?? "0"
+        let dateOfVaccinationAsString = hcert.statement.info.filter{ $0.header == l10n("vaccine.date")}.first?.content
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = .current
+        dateFormatter.timeStyle = .none
+        dateFormatter.dateStyle = .medium
+        let dateOfVaccination = dateFormatter.date(from: dateOfVaccinationAsString!)
+        let vaccineValidityStart = Calendar.current.date(byAdding: .day, value: Int(vaccineStartDays) ?? 0, to: dateOfVaccination!)!
+        let vaccineValidityEnd = Calendar.current.date(byAdding: .day, value: Int(vaccineEndDays) ?? 0, to: dateOfVaccination!)!
+        
+        return (Date() > vaccineValidityStart && Date() < vaccineValidityEnd)
+    }
+    
+    func getDosesFromDoseString(from doseString: String) -> [Int] {
+        let doseStringArray = doseString.components(separatedBy: CharacterSet.decimalDigits.inverted)
+        return doseStringArray.compactMap { Int($0) }
+    }
+}

--- a/Verifier/Classes/Result/VerificationViewModel.swift
+++ b/Verifier/Classes/Result/VerificationViewModel.swift
@@ -13,6 +13,21 @@ enum Status {
     case invalidQR
 }
 
+func validateWithMedicalRules(_ hcert: HCert) -> Bool {
+    switch hcert.type {
+    case .test:
+        let testValidityCheck = TestValidityCheck()
+        return testValidityCheck.checkTestDate(hcert) && testValidityCheck.checkTestResult(hcert)
+    case .vaccine:
+        print(hcert.statement.info)
+        let vaccineValidityCheck = VaccineValidityCheck()
+        return vaccineValidityCheck.checkVaccineDate(hcert)
+    case .recovery:
+        let recoveryValidityCheck = RecoveryValidityCheck()
+        return recoveryValidityCheck.checkRecoveryDate(hcert)
+    }
+}
+
 class VerificationViewModel {
 
     var status: Status
@@ -26,12 +41,12 @@ class VerificationViewModel {
         }
         else {
             if hCert!.isValid {
-                status = .valid
+                if validateWithMedicalRules(hCert!) {
+                    status = .valid
+                } else {
+                    status = .expired
+                }
             }
-//            waiting for medical rules
-//            else if !validateMedicalRules(hCert!) {
-//                status = .expired
-//            }
             else {
                 status = .invalidQR
             }


### PR DESCRIPTION
feat: added medical rules management

added call to settings api to retrieve settings (medical rules)
added Setting model to manage settings api response
added Settings array to LocalData to save response locally and allow offline usage
added models for validation of each hcert case (recovery, test, vaccine)
added medical rules validation in validation page and managed correct navigation to expired page in case rules are not validated
