### PR TITLE
feature: manage service errors

### DIFF
--- a/DGCAVerifier/Services/GatewayConnection.swift
+++ b/DGCAVerifier/Services/GatewayConnection.swift
@@ -91,14 +91,19 @@ class GatewayConnection {
                         interceptor: nil,
                         requestModifier: nil)
             .response {
+                guard let status = $0.response?.statusCode else {
+                    completion?(nil, nil, "server.error.genericError".localized)
+                    return
+                }
+                
                 // Everything ok, all certificates downloaded, no more content
-                if let status = $0.response?.statusCode, status == 204 {
+                if status == 204 {
                     completion?(nil, nil, nil)
                     return
                 }
                 
-                if let status = $0.response?.statusCode, status == 403 {
-                    completion?(nil, nil, "server.error.noAuthorization".localized)
+                if status > 204 {
+                    completion?(nil, nil, "server.error.errorWithStatus".localized + "\(status)")
                     return
                 }
                 

--- a/Verifier/Classes/Home/HomeViewController.swift
+++ b/Verifier/Classes/Home/HomeViewController.swift
@@ -98,9 +98,20 @@ class HomeViewController: UIViewController {
         self.present(alertController, animated: true, completion: nil)
     }
 
+    private func showNoKeysAlert() {
+        let alertController = UIAlertController(title: "alert.noKeys.title".localized, message: "alert.noKeys.message".localized, preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alertController.addAction(okAction)
+        
+        self.present(alertController, animated: true, completion: nil)
+    }
+    
     @IBAction func scan(_ sender: Any) {
         if viewModel.isVersionOutdated.value ?? false {
             showOutdatedAlert()
+        } else if LocalData.sharedInstance.lastFetch.timeIntervalSince1970 == 0 {
+            showNoKeysAlert()
         }
         else {
             coordinator?.showCamera()

--- a/Verifier/Classes/Home/HomeViewModel.swift
+++ b/Verifier/Classes/Home/HomeViewModel.swift
@@ -18,7 +18,8 @@ class HomeViewModel {
     private func updateLastUpdateDate() {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "dd/MM/yyyy, HH:mm"
-        lastUpdateText.value = "home.lastUpdate".localized + dateFormatter.string(from: LocalData.sharedInstance.lastFetch)
+        
+        lastUpdateText.value = "home.lastUpdate".localized + (LocalData.sharedInstance.lastFetch.timeIntervalSince1970 > 0 ? dateFormatter.string(from: LocalData.sharedInstance.lastFetch) : "home.notAvailable".localized)
     }
     
     private func isCurrentVersionOutdated() -> Bool {
@@ -31,17 +32,16 @@ class HomeViewModel {
     
     func loadCertificates() {
         LocalData.initialize { [weak self] in
-            if LocalData.sharedInstance.lastFetch.timeIntervalSince1970 != 0 {
-                self?.updateLastUpdateDate()
-                self?.isScanEnabled.value = true
-                self?.isVersionOutdated.value = self?.isCurrentVersionOutdated()
-            }
+            self?.updateLastUpdateDate()
+            self?.isScanEnabled.value = true
+            self?.isVersionOutdated.value = self?.isCurrentVersionOutdated()
+            
             
             self?.connection.start { [weak self] error, isVersionOutdated in
                 self?.isLoading.value = false
                 
-                if error != nil {
-                    self?.lastUpdateText.value = error
+                if let error = error {
+                    print(error)
                     return
                 }
                 

--- a/Verifier/Resources/en.lproj/Localizable.strings
+++ b/Verifier/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "home.intro" = "This is the system that scans and validates a QR code of a vaccination ticket";
 "home.loading" = "Loading certificates...";
 "home.lastUpdate" = "Last update: ";
+"home.notAvailable" = "N/A";
 
 "result.valid.title" = "Valid vaccination";
 "result.valid.description" = "For security reasons, please present also an identification document (e.g. national id card)";
@@ -34,7 +35,11 @@
 
 "alert.barcodeError.title" = "Barcode error";
 
-"server.error.noAuthorization" = "403 - No authorization";
+"server.error.errorWithStatus" = "Returned error with status ";
+"server.error.genericError" = "Generic error in service invocation";
 
 "alert.versionOutdated.title" = "Update required";
 "alert.versionOutdated.message" = "To continue using the app, download the new version from the store";
+
+"alert.noKeys.title" = "Cannot scan";
+"alert.noKeys.message" = "App must connect to the network at least once to be used";

--- a/Verifier/Resources/it.lproj/Localizable.strings
+++ b/Verifier/Resources/it.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "home.intro" = "Questo è il sistema di scannerizzazione dei QR code delle certificazioni di idoneità Covid19.";
 "home.loading" = "Caricamento certificati in corso...";
 "home.lastUpdate" = "Ultimo aggiornamento: ";
+"home.notAvailable" = "N/A";
 
 "result.valid.title" = "Certificato valido";
 "result.valid.description" = "Per sicurezza, confrontare i seguenti dati con un documento ufficiale (es: Carta d'Identità).";
@@ -34,7 +35,11 @@
 
 "alert.barcodeError.title" = "Errore nel QR code";
 
-"server.error.noAuthorization" = "403 - Non autorizzato";
+"server.error.errorWithStatus" = "Ricevuto errore con status ";
+"server.error.genericError" = "Errore generico nell'invocazione del servizio";
 
 "alert.versionOutdated.title" = "Aggiornamento richiesto";
 "alert.versionOutdated.message" = "Per continuare ad utilizzare l’applicazione, scarica la nuova versione dallo store";
+
+"alert.noKeys.title" = "Impossibile scansionare";
+"alert.noKeys.message" = "L'applicazione deve connettersi alla rete almeno una volta per essere utilizzata";


### PR DESCRIPTION
better service error management in Gateway
added alert that blocks scanning if certificates have never been fetched
added not available label if certificates are not downloaded
values for last update, scan enabled and version update are updated even in case of a service error
added localised strings