### PR TITLE
fix: name order

### DIFF
--- a/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
+++ b/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
@@ -28,7 +28,7 @@ import SwiftDGC
 
 extension HCert {
     
-    var name: String { firstName + " " + lastName }
+    var name: String { lastName + " " + firstName }
     
     var firstName: String { body["nam"]["gn"].string ?? "" }
     


### PR DESCRIPTION
inverted first name and last name to align to android app