### PR TITLE
feature: error-40x-status

### DIFF
--- a/DGCAVerifier/Pages/Home/HomeViewController.swift
+++ b/DGCAVerifier/Pages/Home/HomeViewController.swift
@@ -299,6 +299,11 @@ class HomeViewController: UIViewController {
         showCRL(true)
     }
     
+    private func networkStatusError() {
+        progressView.error(with: sync.progress, noSize: true)
+        showCRL(true)
+    }
+    
     private func showCRL(_ value: Bool) {
         lastFetchContainer.isHidden = value
         progressContainer.isHidden = !value
@@ -310,11 +315,12 @@ extension HomeViewController: CRLSynchronizationDelegate {
     
     func statusDidChange(with result: CRLSynchronizationManager.Result) {
         switch result {
-        case .downloadReady:    crlDownloadNeeded()
-        case .downloading:      showDownloadingProgress()
-        case .completed:        downloadCompleted()
-        case .paused:           downloadPaused()
-        case .error:            downloadError()
+        case .downloadReady:        crlDownloadNeeded()
+        case .downloading:          showDownloadingProgress()
+        case .completed:            downloadCompleted()
+        case .paused:               downloadPaused()
+        case .error:                downloadError()
+        case .statusNetworkError:   networkStatusError()
         }
     }
 }

--- a/DGCAVerifier/SupportingFiles/en.lproj/Localizable.strings
+++ b/DGCAVerifier/SupportingFiles/en.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "crl.update.loading.title" = "Aggiornamento lista dei certificati revocati in corso...";
 "crl.update.resume.title" = "L'aggiornamento della lista dei certificati revocati non è terminato. Assicurati di essere connesso a internet e clicca per continuare.";
 "crl.update.title" = "L'applicazione VerificaC19 necessita di aggiornare la lista dei certificati revocati, scaricando ed elaborando pacchetti dati per un totale di %@ MB.";
+"crl.update.title.no.size" = "L'applicazione VerificaC19 necessita di aggiornare la lista dei certificati revocati.";
 "crl.update.message" = "Controlla il piano dati della tua connessione oppure connetti una rete wi-fi prima di procedere. Il tempo di aggiornamento dipende dalla velocità di connessione e dal tipo di device in uso.\n\nLa lista verrà aggiornata ogni 24 ore con pacchetti di aggiornamento dati che di solito non supereranno i pochi KB. In caso un prossimo aggiornamento supererà i 5MB si visualizzerà un nuovo messaggio come il presente";
 "crl.update.download.now" = "Scarica ora";
 "crl.update.try.later" = "Più tardi";

--- a/DGCAVerifier/SupportingFiles/it.lproj/Localizable.strings
+++ b/DGCAVerifier/SupportingFiles/it.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "crl.update.loading.title" = "Aggiornamento lista dei certificati revocati in corso...";
 "crl.update.resume.title" = "L'aggiornamento della lista dei certificati revocati non è terminato. Assicurati di essere connesso a internet e clicca per continuare.";
 "crl.update.title" = "L'applicazione VerificaC19 necessita di aggiornare la lista dei certificati revocati, scaricando ed elaborando pacchetti dati per un totale di %@ MB.";
+"crl.update.title.no.size" = "L'applicazione VerificaC19 necessita di aggiornare la lista dei certificati revocati.";
 "crl.update.message" = "Controlla il piano dati della tua connessione oppure connetti una rete wi-fi prima di procedere. Il tempo di aggiornamento dipende dalla velocità di connessione e dal tipo di device in uso.\n\nLa lista verrà aggiornata ogni 24 ore con pacchetti di aggiornamento dati che di solito non supereranno i pochi KB. In caso un prossimo aggiornamento supererà i 5MB si visualizzerà un nuovo messaggio come il presente";
 "crl.update.download.now" = "Scarica ora";
 "crl.update.try.later" = "Più tardi";

--- a/DGCAVerifier/UIComponents/CustomViews/ProgressView/ProgressView.swift
+++ b/DGCAVerifier/UIComponents/CustomViews/ProgressView/ProgressView.swift
@@ -41,15 +41,15 @@ class ProgressView: AppView {
         messageLabel.text = "crl.update.resume.title".localized
     }
     
-    func error(with progress: CRLProgress) {
+    func error(with progress: CRLProgress, noSize: Bool = false) {
         downloading(with: progress)
         stop()
         
         messageLabel.isHidden = false
-        showMoreLabel.isHidden = false
+        showMoreLabel.isHidden = noSize
         confirmButton.isHidden = false
             
-        messageLabel.text = "crl.update.title".localizeWith(progress.remainingSize)
+        messageLabel.text = (noSize ? "crl.update.title.no.size" : "crl.update.title").localizeWith(progress.remainingSize)
     }
     
     private func start() {


### PR DESCRIPTION
- Added HTTP error handling for status checks as well
- Added case to `CRLSynchronizationDelegate` to handle 40x errors on the UI
- Added `crl.update.title` localized string variation
- Added `noSize` to error method