### PR TITLE
fix: partial drl scan alert

### DIFF
--- a/DGCAVerifier/Pages/Home/HomeViewController.swift
+++ b/DGCAVerifier/Pages/Home/HomeViewController.swift
@@ -265,7 +265,7 @@ class HomeViewController: UIViewController {
                 return
             }
             guard isCRLDownloadCompleted else {
-                showAlert(key: "no.crl.download")
+                showAlert(key: "crl.update.resume")
                 return
             }
         }

--- a/DGCAVerifier/SupportingFiles/en.lproj/Localizable.strings
+++ b/DGCAVerifier/SupportingFiles/en.lproj/Localizable.strings
@@ -64,6 +64,9 @@
 "alert.no.crl.download.title" = "Impossibile scansionare";
 "alert.no.crl.download.message" = "L'aggiornamento della lista dei certificati revocati è in corso. Attendere la fine del download per procedere con le scansioni.";
 
+"alert.crl.update.resume.title" = "Impossibile scansionare";
+"alert.crl.update.resume.message" = "L'aggiornamento della lista dei certificati revocati non è terminato. Assicurati di essere connesso a internet e clicca per continuare.";
+
 "alert.no.connection.title" = "Connessione internet assente";
 "alert.no.connection.message" = "Connessione internet assente. Assicurati di essere connesso alla rete e riprova.";
 

--- a/DGCAVerifier/SupportingFiles/it.lproj/Localizable.strings
+++ b/DGCAVerifier/SupportingFiles/it.lproj/Localizable.strings
@@ -64,6 +64,9 @@
 "alert.no.crl.download.title" = "Impossibile scansionare";
 "alert.no.crl.download.message" = "L'aggiornamento della lista dei certificati revocati è in corso. Attendere la fine del download per procedere con le scansioni.";
 
+"alert.crl.update.resume.title" = "Impossibile scansionare";
+"alert.crl.update.resume.message" = "L'aggiornamento della lista dei certificati revocati non è terminato. Assicurati di essere connesso a internet e clicca per continuare.";
+
 "alert.no.connection.title" = "Connessione internet assente";
 "alert.no.connection.message" = "Connessione internet assente. Assicurati di essere connesso alla rete e riprova.";
 


### PR DESCRIPTION
Added new localized string that provides the user with a more descriptive alert message as per why scanning is blocked when DRL have yet to be fully downloaded and stored.