### PR TITLE
Fix: person details when fn and gn are missing

### DIFF
--- a/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
+++ b/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
@@ -37,7 +37,7 @@ extension HCert {
         let fullName: String = lastName + " " + firstName
         let stdfullName: String = stdlastName + " " + stdfirstName + " " + firstName
         
-        if lastname.isEmpty {
+        if lastName.isEmpty {
             return stdfullName
         } else {
             return fullName

--- a/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
+++ b/DGCAVerifier/Utils/HCert/HCert+PersonalData.swift
@@ -28,11 +28,22 @@ import SwiftDGC
 
 extension HCert {
     
-    var name: String { lastName + " " + firstName }
-    
-    var firstName: String { body["nam"]["gn"].string ?? "" }
-    
-    var lastName: String { body["nam"]["fn"].string ?? "" }
+    var name: String {
+        let firstName: String = body["nam"]["gn"].string ?? ""
+        let lastName: String = body["nam"]["fn"].string ?? ""
+        let stdfirstName: String = body["nam"]["gnt"].string ?? ""
+        let stdlastName: String = body["nam"]["fnt"].string ?? ""
+        
+        let fullName: String = lastName + " " + firstName
+        let stdfullName: String = stdlastName + " " + stdfirstName + " " + firstName
+        
+        if lastname.isEmpty {
+            return stdfullName
+        } else {
+            return fullName
+        }
+        
+    }
     
     var birthDate: String {
         //  TODO: use date formats to be placed inside Constants


### PR DESCRIPTION
This PR fixes output display issues with those certificates that don't include the `fn` (familyName) and `gn` (givenName) fields, but for instance only the `fnt` field.

-----------------

## **Issue Details :**

Some foreign certificates only include the `fnt` field = no `fn` and `gn` fields.
Therefore - owing to the current usage of fun setPersonData in VerificationViewController - the validation output of such certificates doesn't contain any person details of the certificate holder.


- Reference : https://github.com/ministero-salute/it-dgc-verificaC19-ios/issues/136

- You can check against the DGC ACC samples inside the official EU DGCA Quality Assurance repo, for instance [SG 1.3.0](https://github.com/eu-digital-green-certificates/dcc-quality-assurance/tree/main/SG/1.3.0)

-----------------

## **Fix description :**

It checks if the `fn` field name is null/empty.
- If true setPersonData gets cert.name as `fnt + gnt + gn` in order to arrange the text for the person details into the validation output.
- Otherwise setPersonData gets cert.name as  `fn + gn` .